### PR TITLE
feat: enable Express response manipulation by app and possibility to bootstrap the app.

### DIFF
--- a/essence/src/lib/actionAdapter.ts
+++ b/essence/src/lib/actionAdapter.ts
@@ -18,6 +18,7 @@ function wrapActionHandler(actionHandler: ActionHandler): RequestHandler {
       pathParams: req.params,
       queryParams: req.query,
       requestBody: req.body,
+      response: res
     }
     const actionOutput = await actionHandler(context)
     convertActionOutputToExpressResponse(actionOutput, res)

--- a/essence/src/lib/bootstrap.ts
+++ b/essence/src/lib/bootstrap.ts
@@ -1,0 +1,18 @@
+import logger from "./logger";
+
+export default function bootstrap(app: any) {
+    // assumes snz is located inside node_modules.
+    let bootstrapFilePath = '../../../../bootstrap'
+  
+    // @ts-ignore assumes there is a bootstrap module in in app's project root folder.
+    import(bootstrapFilePath).then(bootstrap => {
+      bootstrap.default(app)
+    }).catch(e => {
+      import(`${bootstrapFilePath}.js`).then(bootstrap => {
+        bootstrap.default(app)
+      }).catch(e => {
+        logger.info(e)
+        logger.info(`[INFO] No bootstrap.ts/bootstrap.js module found. ${e.message.split(" imported ")[0]}.`)
+      })
+    })
+  }

--- a/essence/src/lib/server.ts
+++ b/essence/src/lib/server.ts
@@ -5,6 +5,8 @@ import logger from "./logger"
 import { createRouter, RegisterRoutesFn } from "./router"
 import { Server } from "http"
 import { promisify } from "util"
+import { Express } from "express"
+import bootstrap from "./bootstrap"
 
 require("ts-node").register({
   transpileOnly: true, // don't apply TS type checks to code in actions
@@ -20,6 +22,7 @@ require("ts-node").register({
 renderSSR(null)
 
 export type EssenceServer = {
+  app: Express
   startServer: () => Promise<void>
   stopServer: () => Promise<void>
   registerPathActions: RegisterRoutesFn
@@ -28,6 +31,7 @@ export type EssenceServer = {
 
 export async function createServer(port = 3553): Promise<EssenceServer> {
   const app = express()
+  bootstrap(app)
   const router = createRouter(app)
 
   let boundPort: number | null = null
@@ -48,6 +52,7 @@ export async function createServer(port = 3553): Promise<EssenceServer> {
   }
 
   return {
+    app,
     startServer,
     stopServer,
     registerPathActions: router.registerPathActions,

--- a/essence/src/lib/types.ts
+++ b/essence/src/lib/types.ts
@@ -5,6 +5,7 @@ export type ActionContext = {
   pathParams: Record<string, string>
   queryParams: ParsedQs
   requestBody: any
+  response: any
 
   // TODO: body, rawBody, headers, cookies, etc. etc.
 }


### PR DESCRIPTION
Sometimes it's necessary for applications to manipulate HTTP response object (i.e.: change status code to something else) depending of business flow.

This PR enables this as I think it would be a nice feature to have in essence-framework.